### PR TITLE
Validator adjustments

### DIFF
--- a/app/registry.hs
+++ b/app/registry.hs
@@ -83,10 +83,10 @@ parseCLI :: Parser CLI
 parseCLI = Opt.subparser $
   command' "validate-submission" "Validate stake pool registry entry submission."
     (ValidateSubmission
-       <$> (RegistryRoot <$> parseFilePath
+       <$> (RegistryRoot <$> parseFilePath "DIR"
               "registry-root"
               "Root directory of the testnet stake pool registry.")
-       <*> (SubmissionFile <$> parseFilePath
+       <*> (SubmissionFile <$> parseFilePath "FILEPATH"
               "registry-submission"
               "File to scrutinise for registry submission.")) <>
   command' "prepare-submission" "Make a stake pool registry entry submission."
@@ -100,7 +100,7 @@ parseCLI = Opt.subparser $
        <*> parsePledgeAddress
               "pledge-address"
               "Pledge address, Bech32-encoded string."
-       <*> (PublicKeyFile <$> parseFilePath
+       <*> (PublicKeyFile <$> parseFilePath "FILEPATH"
               "public-key-file"
               "Public key file, Bech32-encoded -- output of 'jcli key to-public'"))
  where
@@ -119,9 +119,9 @@ parseCLI = Opt.subparser $
      (Opt.option (Opt.eitherReader validatePledgeAddress) $
        long opt <> help desc <> metavar "PLEDGE-ADDRESS")
 
-   parseFilePath :: String -> String -> Parser FilePath
-   parseFilePath optname desc =
-     strOption $ long optname <> metavar "PUBLICKEY-FILE" <> help desc
+   parseFilePath :: String -> String -> String -> Parser FilePath
+   parseFilePath meta optname desc =
+     strOption $ long optname <> metavar meta <> help desc
 
    command'
      :: Prelude.String
@@ -146,7 +146,7 @@ data CLI
       -- ^ Ticker, 3-4 upper-case ASCII letters.
       !URI.URI
       -- ^ Absolute URI of the stake pool  homepage.
-      !PledgeAddress 
+      !PledgeAddress
       -- ^ Pledge address, Bech32-encoded.
       !PublicKeyFile
       -- ^ Public key file, Bech32-encoded.
@@ -240,7 +240,7 @@ writeRegistrySubmission s = do
 
    outputName :: Text
    outputName = bechUnprefixedText . unId $ sId s
-     
+
 --------------------------------------------------------------------------------
 -- * Main validator
 --

--- a/app/registry.hs
+++ b/app/registry.hs
@@ -391,8 +391,9 @@ validatePublicKey text =
 
 validateTicker :: MonadFail m => String -> m Ticker
 validateTicker s =
-  if (length s >= 3 && length s <= 5
-       && all Char.isAsciiUpper s)
+  if length s >= 3
+  && length s <= 5
+  && all (\c -> Char.isAlphaNum c && (Char.isDigit c || Char.isUpper c)) s
   then pure $ Ticker (pack s)
   else fail $ "Not an uppercase ASCII of length 3 to 5: " <> take 32 s
 

--- a/app/registry.hs
+++ b/app/registry.hs
@@ -104,7 +104,7 @@ parseCLI = Opt.subparser $
               "ticker"
               "3 to 5 upper-ASCII-character stake pool ticker."
        <*> parseURI
-              "pool-web"
+              "homepage"
               "Absolute URI of the stake pool's public web presence."
        <*> parsePledgeAddress
               "pledge-address"

--- a/lib.sh
+++ b/lib.sh
@@ -83,6 +83,6 @@ validateCommitMessage() {
 
 validateSignature() {
         pub=$(mktemp "XXXXXXXXX.pub")
-        jq '.id' ${entry} | xargs echo > ${pub}
+        jq '.owner' ${entry} | xargs echo > ${pub}
         jcli key verify --public-key ${pub} --signature "${sig}" "${entry}"
 }

--- a/tests/mkall.sh
+++ b/tests/mkall.sh
@@ -30,7 +30,7 @@ $def  '' '' \
 $def --private ${key01} --no-generate '.ticker="OTHR"' '' \
 "01-update-ticker"       "OTHR:  update"
 
-$def --private ${key01} --no-generate '.pledge_address="ed25519_pk1uadm2958qvrta7e0j275ftrxtth5p9txaqq3gg9z5fxg0zxq0d3sa9yyys"' '' \
+$def --private ${key01} --no-generate '.pledge_address="addr1svklmf8yl78x9cw30ystvprhxtm790k4380xlsjrjqn2p8nekup8uvzfezl"' '' \
 "02-update-pledge"       "FST:  update" "FST"
 
 ###
@@ -45,9 +45,9 @@ i=${start}
 ### change structure
 ###
 f=$(ls *.json | head -n1 | xargs echo)
-id=$(jq .id <$f | xargs echo | cut -d_ -f2)
-echo f=${f} id=${id}
-eval $inc; $def --no-generate --no-sig --id "${id}" '' "mv ${id}.{json,sig}" \
+owner=$(jq .owner)
+echo f=${f} owner=${owner}
+eval $inc; $def --no-generate --no-sig --owner "${owner}" '' "mv ${owner}.{json,sig}" \
 "$i-modify" "$i:  Modify!"
 
 eval $inc; $def --no-generate --no-sig '' 'rm *.json' \
@@ -71,14 +71,14 @@ eval $inc; $def --no-generate --no-sig '' 'touch ../{somewhere,something}' \
 eval $inc; $def --no-generate --no-sig '' 'mkdir somewhere; touch somewhere/{else,and.again}' \
 "$i-not-in-registry-either"
 
-eval $inc; $def  '' 'cp ${id}.json ${id}1.json' \
+eval $inc; $def  '' 'cp ${owner}.json ${owner}1.json' \
 "$i-too-many-files"
 
 ###
 ### file names
 ###
-eval $inc; $def  '' 'mv ${id}.json terrible.json' \
-"$i-file-id"
+eval $inc; $def  '' 'mv ${owner}.json terrible.json' \
+"$i-file-owner"
 
 ###
 ### file content
@@ -93,25 +93,25 @@ eval $inc; $def  'del(.homepage)' '' \
 "$i-too-few-fields"
 
 ###
-### file content: Id
+### file content: Owner
 ###
-eval $inc; $def  'del(.id)' '' \
+eval $inc; $def  'del(.owner)' '' \
 "$i-missing-mandatory"
 
 eval $inc; $def  'del(.pledge_address)' '' \
 "$i-missing-mandatory-pledge"
 
-eval $inc; $def  '.id=3.141592653589793' '' \
+eval $inc; $def  '.owner=3.141592653589793' '' \
 "$i-mandatory-field-type"
 
-eval $inc; $def  '.id="ed25519_nsacrypto"' '' \
-"$i-internal-id-length"
+eval $inc; $def  '.owner="ed25519_nsacrypto"' '' \
+"$i-internal-owner-length"
 
-eval $inc; $def  '.id="nsacrypto_pk1dqaghc0luz0m9mr807hyaeprw49rx8ykvpcw6vvldckznl0q0y4qr280s2"' '' \
-"$i-internal-id-format"
+eval $inc; $def  '.owner="nsacrypto_pk1dqaghc0luz0m9mr807hyaeprw49rx8ykvpcw6vvldckznl0q0y4qr280s2"' '' \
+"$i-internal-owner-format"
 
-eval $inc; $def  '.id="ed25519_pk1dqaghc0luz0m9mr807hyaeprw49rx8ykvpcw6vvldckznl0q0y4qr280s2"' '' \
-"$i-id-entry-mismatch"
+eval $inc; $def  '.owner="ed25519_pk1dqaghc0luz0m9mr807hyaeprw49rx8ykvpcw6vvldckznl0q0y4qr280s2"' '' \
+"$i-owner-entry-mismatch"
 
 ###
 ### file content: types
@@ -131,10 +131,10 @@ eval $inc; $def  '.ticker="FST"' '' \
 ###
 ### signature
 ###
-eval $inc; $def  '' 'echo -n ed25519_sig1se9knlfd3uny0mp5wc8yc0f20vsz4yjm2c2zklg6fsdy7500w8vln6qwtfnseajn6g3ztyfll8swjxef0804sge67m7huh3mup5dspg3juxmu > ${id}.sig' \
+eval $inc; $def  '' 'echo -n ed25519_sig1se9knlfd3uny0mp5wc8yc0f20vsz4yjm2c2zklg6fsdy7500w8vln6qwtfnseajn6g3ztyfll8swjxef0804sge67m7huh3mup5dspg3juxmu > ${owner}.sig' \
 "$i-signature-mismatch"
 
-eval $inc; $def  '' 'echo 1 > ${id}.sig' \
+eval $inc; $def  '' 'echo 1 > ${owner}.sig' \
 "$i-malformed-signature"
 
 cat <<EOF


### PR DESCRIPTION
See also: https://github.com/input-output-hk/testnet-stake-pool-registry-validator/issues/2

I highly suggest reviewing this commit-by-commit, the git history is somewhat meaningful and should help make the review little easier.

I did some smoke tests, fiddling a bit with the CLI, looks _okay_:

```
$ stack exec -- registry prepare-submission --name "My Awesome Pool" --ticker KTORZ --homepage https://ktorz.dev --pledge-address addr1svklmf8yl78x9cw30ystvprhxtm790k4380xlsjrjqn2p8nekup8uvzfezl --public-key-file key.pub
Writing submission to ed25519_pk1vjtm38up3t8u2dr0rkhe4gr53xy70xy8k7c25w5qcdte4l6vt20skacgsf.json
You'll need to provide a signature in ed25519_pk1vjtm38up3t8u2dr0rkhe4gr53xy70xy8k7c25w5qcdte4l6vt20skacgsf.sig
```

```
$ stack exec -- registry prepare-submission --name "My Awesome Pool" --ticker KTORZ --homepage https://ktorz.dev --pledge-address addr1svklmf8yl78x9cw30ystvprhxtm790k4380xlsjrjqn2p8nekup8uvzfezl --description patate --public-key-file key.pub
Writing submission to ed25519_pk1vjtm38up3t8u2dr0rkhe4gr53xy70xy8k7c25w5qcdte4l6vt20skacgsf.json
You'll need to provide a signature in ed25519_pk1vjtm38up3t8u2dr0rkhe4gr53xy70xy8k7c25w5qcdte4l6vt20skacgsf.sig
```

```
$ stack exec -- registry prepare-submission --name "My Awesome Pool" --ticker KTORZ --homepage https://ktorz.dev --pledge-address addr1ad78w5qj8tcfxectg0cxkcsu8lxedasd2fx6ycxqmwkfs6l0j9zq0lw2ug --public-key-file key.pub
option --pledge-address: Unrecognized network discriminant for the given address.
```

```
$ stack exec -- registry prepare-submission --name "My Awesome Pool" --ticker KTORZ --homepage https://ktorz.dev --pledge-address ed25519_sk1ad78w5qj8tcfxectg0cxkcsu8lxedasd2fx6ycxqmwkfs6l0j9zq04d2up --public-key-file key.pub
option --pledge-address: Pledge address has an unexpected human-readable part ( "ed25519_sk" ). Expected prefix is: "addr"
```
