### PR TITLE
remove superfluous (<?>) and use (.:?) for the description

### DIFF
--- a/app/registry.hs
+++ b/app/registry.hs
@@ -515,12 +515,12 @@ instance FromJSON Submission where
   parseJSON = AE.withObject "Submission" $ \v->
     case validateFields v of
       [] -> Submission
-              <$> v .: "owner" <?> AE.Key "owner"
-              <*> v .: "name" <?> AE.Key "name"
-              <*> v .: "description" <?> AE.Key "description"
-              <*> v .: "ticker" <?> AE.Key "ticker"
-              <*> v .: "homepage" <?> AE.Key "homepage"
-              <*> v .: "pledge_address" <?> AE.Key "pledge_address"
+              <$> v .: "owner"
+              <*> v .: "name"
+              <*> v .:? "description"
+              <*> v .: "ticker"
+              <*> v .: "homepage"
+              <*> v .: "pledge_address"
       xs -> fail $ List.unlines xs
     where validateFields :: AE.Object -> [String]
           validateFields v =


### PR DESCRIPTION
1. `aeson` documentation says the following about `<?>`:

  Add JSON Path context to a parser
  When parsing a complex structure, it helps to annotate (sub)parsers with context, so that if an error occurs, you can find its location.

  withObject "Person" $ \o ->
    Person
      <$> o .: "name" <?> Key "name"
      <*> o .: "age"  <?> Key "age"

  (Standard methods like '(.:)' already do this.)

2. The description is actually optional, requiring `.:` forces the key
to be present in the JSON file (possibly `null`). Using `.:?` removes
this limitation.