### PR TITLE
remove the single-commit validation

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -38,9 +38,6 @@ validateGitHistory() {
         local delta="${base}..HEAD"
 
         git log --oneline ${base}
-        local history_length=$(git log --oneline ${delta} | wc -l)
-        test "${history_length}" = 1 ||
-                error "Git history:  submissions must contain exactly a single commit (this one has ${history_length})."
 
         banner "Validating change structure.."
 


### PR DESCRIPTION
As discussed with the CF and Samuel, we agreed to remove the "must be a single commit" limitation on the validation. 

Why? 

There might the case where two conflicting PRs are trying to take ownership of a particular ticker not yet existing on the registry. Both PRs validation may pass independently but, not together. Still, CI doesn't re-run between merges by default so we might be merging two conflicting PRs if not careful.

Multiple option exists to cope with this:

- We could use bors and have a staging area. However, this requires some extra setup and, is an extra learning curve for anyone in the CF to use.

- We can enable a branch protection on GH to force every PR to be up-to-date with latest master before merging. 

    - Without any other change, this would force every user to rebase their PR after every merge and is kinda not practical from a UX perspective.

    - Now, if we remove the single-commit limitation from the validator, CF operators can simply use the GH interface to "Update Branch" (there's a button for it) when they are lagging behind. This pushes a single merge commit to the branch and will effectively re-run the CI validation.