### PR TITLE
disallow duplicate keys in JSON files

### DIFF
--- a/app/registry.hs
+++ b/app/registry.hs
@@ -322,8 +322,8 @@ validateRegistrySubmission (RegistryRoot root) (SubmissionFile fp) = do
     Right x -> pure x
 
   contents <- lift $ BSL.fromStrict <$> BS.readFile afp
-  case AE.eitherDecode contents of
-    Left e -> err $ ["Submission content:\n" <> pack e]
+  case AE.eitherDecodeWith AE.jsonNoDup AE.ifromJSON contents of
+    Left (_, e) -> err $ ["Submission content:\n" <> pack e]
     Right entry -> do
 
       checks $


### PR DESCRIPTION
Without this fix, this JSON file would be deemed valid:

```json
{
  "owner": "ed25519_pk1yrys3un0yw3na8k9zwk9pu6qey2ggmcq3xd6x5cm8kvcdeh0wt5s2rx0q8",
  "name": "CardanoStakePool.io",
  "ticker": "CSP",
  "ticker": "AAA",
  "description": "A secure and reliable stake pool. No fixed fee, only 2% of variable fee.",
  "homepage": "https://cardanostakepool.io",
  "pledge_address": "addr1s5svjz8jdu36x057c5f6c58ngry3fpr0qzyehg6nrv7enphxaaewjfgx7r6"
}
```

With the fix, we know get:

```
 $ registry validate-submission --registry-root $(pwd) --registry-submission registry/ed25519_pk1yrys3un0yw3na8k9zwk9pu6qey2ggmcq3xd6x5cm8kvcdeh0wt5s2rx0q8.json
Errors:
Submission content:
Failed reading: found duplicate key: "ticker"
```
